### PR TITLE
feat: make file output deterministic by sorting file data by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ npm install markdown-json
 markdown-json [OPTIONS] [ARGS]
 
 Options:
-  -c, --config [STRING]  settings file (Default is ./settings.json)
-  -w, --cwd [STRING]     work directory (Default is ./)
-  -d, --src [STRING]     file(s) directory (Default is ./)
-  -p, --filePattern [STRING]file(s) directory (Default is **/*.md)
-  -i, --ignore STRING    Ignore file pattern
-  -d, --dist [STRING]    output file directory (Default is ./dist/output.json)
-  -D, --display BOOLEAN  enable display mode
-  -S, --server BOOLEAN   enable server
-  -P, --port [NUMBER]    server port (Default is 3001)
-  -h, --help             Display help and usage details
+  -c, --config [STRING]              settings file (Default is ./settings.json)
+  -D, --display BOOLEAN              enable display mode
+  -d, --dist [STRING]                output file directory (Default is ./dist/output.json)
+  -i, --ignore STRING                ignore file pattern
+  -o, --deterministicOrder BOOLEAN   enable deterministic output ordering
+  -p, --filePattern [STRING]         file(s) directory (Default is **/*.md)
+  -P, --port [NUMBER]                server port (Default is 3001)
+  -S, --server BOOLEAN               enable server
+  -s, --src [STRING]                 file(s) directory (Default is ./)
+  -w, --cwd [STRING]                 work directory (Default is ./)
+  -h, --help                         display help and usage details
 ```
 
 ### Require module usage:
@@ -50,7 +51,8 @@ markdownJson(<settingsObj>) // => returns a Promise
   "dist": "example/output.json",
   "metadata": true,
   "server": true,
-  "port": 3001
+  "port": 3001,
+  "deterministicOrder": false
 }
 ```
 
@@ -71,7 +73,8 @@ const settings = {
         dist: 'example/output.json',
         metadata: true,
         server: false,
-        port: 3001
+        port: 3001,
+        deterministicOrder: false
       };
 
 markdownJson(settings).then((data) => {

--- a/example/output.json
+++ b/example/output.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "deterministicOrder": false,
     "server": true,
     "config": "./settings.json",
     "cwd": "./",

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -37,7 +37,9 @@ const writeJson = (files, metalsmith, done) => {
   for (const file in files) {
     data.data.push(transformFileData(files[file], file, settings))
   }
-  data.data.sort((firstFile, secondFile) => firstFile.id < secondFile.id ? -1 : 1)
+  if (settings.deterministicOrder) {
+    data.data.sort((firstFile, secondFile) => firstFile.id < secondFile.id ? -1 : 1)
+  }
 
   json.writeFileSync(settings.dist, data, { spaces: 2 }, err => {
     cli.fatal(err)

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -33,9 +33,11 @@ const writeJson = (files, metalsmith, done) => {
   }
 
   data.app.version = pkg ? pkg.version : 'n/a'
+
   for (const file in files) {
     data.data.push(transformFileData(files[file], file, settings))
   }
+  data.data.sort((firstFile, secondFile) => firstFile.id < secondFile.id ? -1 : 1)
 
   json.writeFileSync(settings.dist, data, { spaces: 2 }, err => {
     cli.fatal(err)

--- a/lib/helpme.js
+++ b/lib/helpme.js
@@ -1,11 +1,12 @@
 module.exports = {
   config: ['c', 'settings file', 'string', './settings.json'],
   cwd: ['w', 'work directory', 'string', './'],
-  src: ['s', 'file(s) directory', 'string', './'],
-  filePattern: ['p', 'file(s) directory', 'string', '**/*.md'],
-  ignore: ['i', 'Ignore file pattern', 'string', ''],
-  dist: ['d', 'output file directory', 'string', './dist/output.json'],
+  deterministicOrder: ['o', 'enable deterministic output ordering', 'boolean', false],
   display: ['D', 'enable display mode', 'boolean', true],
+  dist: ['d', 'output file directory', 'string', './dist/output.json'],
+  filePattern: ['p', 'file(s) directory', 'string', '**/*.md'],
+  ignore: ['i', 'ignore file pattern', 'string', ''],
+  port: ['P', 'server port', 'number', 3001],
   server: ['S', 'enable server', 'boolean', false],
-  port: ['P', 'server port', 'number', 3001]
+  src: ['s', 'file(s) directory', 'string', './']
 }


### PR DESCRIPTION
It was bothering me that every time I rebuilt my project and ran markdown-json, it would change the order of the properties in the output file. This PR fixes it so that the order of the output data is determined by the file structure.